### PR TITLE
fixed: onclick on email

### DIFF
--- a/src/app/api/email/route.js
+++ b/src/app/api/email/route.js
@@ -3,7 +3,7 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-export async function GET() {
+export async function POST() {
   resend.sendEmail({
     from: "Acme <onboarding@resend.dev>",
     to: "prthamesh842003@gmail.com",

--- a/src/app/email/page.js
+++ b/src/app/email/page.js
@@ -9,7 +9,7 @@ const Email = () => {
     async function handleSubmit(e){
         e.preventDefault();
         await fetch('api/email', {
-            method : 'GET',
+            method: 'POST',
             body : JSON.stringify({
                 firstName : "Cosmo"
             })
@@ -19,7 +19,7 @@ const Email = () => {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen py-2">
-        <button onClick={handleSubmit()}>Send Email</button>
+          <button onClick={handleSubmit}>Send Email</button>
     </div>
   );
 };


### PR DESCRIPTION
FIXES #1

You should pass the function reference in the onClick event handler without invoking it.
 Also, when using the GET method, refrain from sending a request body; instead, use the POST method for this purpose.